### PR TITLE
Feature/update transaction tag

### DIFF
--- a/src/main/java/dev/mmussatto/expensetracker/entities/transaction/TransactionMapper.java
+++ b/src/main/java/dev/mmussatto/expensetracker/entities/transaction/TransactionMapper.java
@@ -14,6 +14,8 @@ import org.mapstruct.Mapping;
 import org.mapstruct.Named;
 import org.mapstruct.factory.Mappers;
 
+import java.util.Set;
+
 @Mapper
 public interface TransactionMapper {
 
@@ -41,6 +43,9 @@ public interface TransactionMapper {
 
     @Mapping(target = "id", source = "tagId")
     Tag mapTags (Integer tagId);
+
+    @Mapping(target = "tag.id", source = "tagIds")
+    Set<Tag> mapTagSet (Set<Integer> tagIds);
 
     @Named("mapVendorWithIdAndType")
     default Vendor mapVendor (RequestTransactionDTO source) {

--- a/src/main/java/dev/mmussatto/expensetracker/entities/transaction/TransactionServiceImpl.java
+++ b/src/main/java/dev/mmussatto/expensetracker/entities/transaction/TransactionServiceImpl.java
@@ -101,7 +101,7 @@ public class TransactionServiceImpl implements TransactionService {
                 savedEntity.setCategory(category);
             }
 
-            if (!transaction.getTags().isEmpty()) {
+            if (transaction.getTags() != null) {
                 savedEntity.getTags().clear();
 
                 transaction.getTags().forEach(transactionTag -> {


### PR DESCRIPTION
Closes #75 

Transaction tags can be updated now. If no tagIds is present in the patch request body, the saved tags will not be modified. But if there is an empty set, all saved tags will be deleted.